### PR TITLE
Unbound variable when creating server

### DIFF
--- a/systemd/screen/minecraft/multiple/minecraftctl
+++ b/systemd/screen/minecraft/multiple/minecraftctl
@@ -36,7 +36,7 @@ command=$1
 instance=$2
 shift 2
 
-if [[ ! -d "$WORKING_DIRECTORY/$2" && "$command" != create ]]; then
+if [[ ! -d "$WORKING_DIRECTORY/$instance" && "$command" != create ]]; then
   echo "Unknown instance: $instance" >&2
   exit 2
 fi


### PR DESCRIPTION
Fixes `$2: undbound variable` error when creating a server